### PR TITLE
Use centos:7 for building the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Tuleap All In One ##
-FROM centos:6
+FROM centos:7
 
 COPY Tuleap.repo /etc/yum.repos.d/
 COPY remi-safe.repo /etc/yum.repos.d/


### PR DESCRIPTION
This pull request solves #70 .
Unfortunately, I was not able to test the change because running `docker build` returns the following error:

```
/bin/sh: /sbin/service: No such file or directory
The command '/bin/sh -c sed -i '/session    required     pam_loginuid.so/c\#session    required     pam_loginuid.so' /etc/pam.d/sshd &&     sed -i '/session    required   pam_loginuid.so/c\#session    required   pam_loginuid.so' /etc/pam.d/crond &&     sed -i '/\[main\]/aexclude=php-pecl-apcu' /etc/yum.conf &&     /sbin/service sshd start &&     rpm --rebuilddb &&     yum install -y     --exclude="tuleap-plugin-referencealias*, tuleap-plugin-im, tuleap-plugin-forumml, tuleap-plugin-fulltextsearch, tuleap-plugin-fusionforge_compat, tuleap-plugin-git, tuleap-plugin-proftpd, tuleap-plugin-tracker-encryption, tuleap-plugin-webdav, tuleap-core-mailman, tuleap-core-cvs"     tuleap-install     tuleap-plugin-*     tuleap-theme-flamingparrot     tuleap-theme-burningparrot     tuleap-documentation     tuleap-customization-default     tuleap-api-explorer &&     yum clean all &&     sed -i 's/#PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config &&     sed -i 's/inet_interfaces = localhost/inet_interfaces = all/' /etc/postfix/main.cf &&     rm -f /etc/ssh/ssh_host_* &&     rm -f /etc/ssl/certs/localhost.crt /etc/pki/tls/private/localhost.key &&     rm -f /home/codendiadm/.ssh/id_rsa_gl-adm* /var/lib/gitolite/.ssh/authorized_keys' returned a non-zero code: 127
```