### PR TITLE
Users cannot switch to fr_FR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN /usr/sbin/groupadd -g 900 -r codendiadm && \
     tuleap-plugin-svn \
     tuleap-theme-burningparrot \
     tuleap-theme-flamingparrot && \
+    localedef -i fr_FR -c -f UTF-8 fr_FR.UTF-8 && \
     sed -i 's/#PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config # Need to keep this one so image scanner are happy
 
 CMD [ "/usr/bin/tuleap-cfg", "docker:tuleap-aio-run" ]


### PR DESCRIPTION
When you try to switch to the French language in the web UI it's like the
change is not taken into account.

Most of Tuleap is internationalized thanks to ext-gettext. ext-gettext
will use the locale that Tuleap via a call to \setlocale(). This call to
\setlocale() will in turn call setlocale(3) [0][1]. setlocale(3) only
do something if the provided locale value is a valid locale
specification. In our case since only the image is built only with some
en_XX locales, switching to French does do anything and the UI stays in
English.

Issue has been identified thanks to request #17969: End to End tests
should use CentOS 7

[0] https://github.com/php/php-src/blob/php-7.3.24/ext/standard/string.c#L36-L43
[1] https://github.com/php/php-src/blob/php-7.3.24/ext/standard/string.c#L4854