### PR TITLE
Setup a basic CI test pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - centos7
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      - name: Build image
+        run: docker build -t tuleap .
+      - name: Launch image
+        timeout-minutes: 10
+        run: docker run --rm -v "$(pwd)/tests/is_tuleap_https_server_up.sh":/is_tuleap_https_server_up.sh tuleap /is_tuleap_https_server_up.sh

--- a/tests/is_tuleap_https_server_up.sh
+++ b/tests/is_tuleap_https_server_up.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+/usr/bin/tuleap-cfg docker:tuleap-aio-run &
+
+is_server_ready() {
+    while : ; do
+        echo "Waiting on the server"
+        sleep 1
+        code=$(curl -k -s -o /dev/null -w "%{http_code}" --resolve tuleap.local:443:127.0.0.1 https://tuleap.local || true)
+        [[ $code -ne 200 ]] || break
+    done
+}
+
+is_server_ready
+
+curl -k --resolve tuleap.local:443:127.0.0.1 https://tuleap.local | grep "Tuleap Community Edition"


### PR DESCRIPTION
The pipeline makes sure the image can be built and that we can access
the homepage.