### PR TITLE
Add the Agile Dashboard plugin in the image by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN /usr/sbin/groupadd -g 900 -r codendiadm && \
     supervisor \
     rh-mysql57-mysql-server \
     tuleap-plugin-tracker \
+    tuleap-plugin-agiledashboard \
     tuleap-plugin-git \
     tuleap-plugin-svn \
     tuleap-theme-burningparrot \


### PR DESCRIPTION
This plugin is used in a lot of the default project templates. It makes sense to have it by default in the image.

References:
#93 
https://chat.tuleap.org/channel/general/thread/jqB5r88GCkuHX9z3f?msg=jqB5r88GCkuHX9z3f